### PR TITLE
fix error for Docker API version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ create-conf: $(RPI_NETWORK_TYPE) bootstrap-conf dhcp-conf ## Add default start u
 
 .PHONY: bootstrap-conf
 bootstrap-conf: ## Add node custom configuration file to be sourced on boot
+	echo "export DOCKER_API_VERSION=1.39" >> $(RPI_HOME)/bootstrap/rpi-env
 	echo "export RPI_HOSTNAME=$(RPI_HOSTNAME)" >> $(RPI_HOME)/bootstrap/rpi-env
 	echo "export RPI_IP=$(RPI_IP)" >> $(RPI_HOME)/bootstrap/rpi-env
 	echo "export RPI_DNS=$(RPI_DNS)" >> $(RPI_HOME)/bootstrap/rpi-env


### PR DESCRIPTION
Hi,

I was trying your awesome scripts and many thanks for this but it got stuck in the installation steps as it was trying to use Docker api version 1.40 and this was not supported. 

The fix was to pin the Docker api to 1.39 
```
export DOCKER_API_VERSION=1.39
```
I added it in the MakeFile and it works again.

Kind regards,
Glenn