### PR TITLE
Fix the Docker API error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ create-conf: $(RPI_NETWORK_TYPE) bootstrap-conf dhcp-conf ## Add default start u
 
 .PHONY: bootstrap-conf
 bootstrap-conf: ## Add node custom configuration file to be sourced on boot
-	echo "export DOCKER_API_VERSION=1.39" >> $(RPI_HOME)/bootstrap/rpi-env
 	echo "export RPI_HOSTNAME=$(RPI_HOSTNAME)" >> $(RPI_HOME)/bootstrap/rpi-env
 	echo "export RPI_IP=$(RPI_IP)" >> $(RPI_HOME)/bootstrap/rpi-env
 	echo "export RPI_DNS=$(RPI_DNS)" >> $(RPI_HOME)/bootstrap/rpi-env

--- a/raspbernetes/install/docker.sh
+++ b/raspbernetes/install/docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-docker_version="5:18.09.0~3-0~raspbian-stretch"
+docker_version="5:19.03.9~3-0~raspbian-stretch"
 
 # add repo list
 curl -fsSL https://download.docker.com/linux/raspbian/gpg | apt-key add -


### PR DESCRIPTION
The install docker commands uses an old version of the Docker API giving errors when trying to use docker commands.

The new version of docker-ce ```5:19.03.9~3-0~raspbian-stretch``` fixed this